### PR TITLE
Add PHPMailer email notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# CRM Gruppo Vitolo
+
+Questo progetto ora utilizza [PHPMailer](https://github.com/PHPMailer/PHPMailer) per inviare una mail di notifica quando viene creato un nuovo ordine.
+
+Per installare la dipendenza è necessario avere Composer. Dopo aver installato Composer, eseguire:
+
+```bash
+composer install
+```
+
+Quindi configurare i parametri SMTP nel file `includes/mailer/mailer_config.php` con le proprie credenziali.

--- a/actions/submit_order_action.php
+++ b/actions/submit_order_action.php
@@ -114,7 +114,11 @@ try {
 
     $conn->commit();
     error_log("[submit_order_action.php] Transazione completata con successo per ordine #{$id_ordine_inserito}.");
-    
+
+    // Invia notifica email con i dettagli dell'ordine
+    require_once __DIR__ . '/../includes/mailer/order_mailer.php';
+    sendOrderNotification($id_ordine_inserito, $nome_richiedente, $centro_costo, $prodotti);
+
     // MODIFICATO: Aggiunto ../
     header("Location: ../form_page.php?status=order_success");
     exit;
@@ -128,8 +132,14 @@ try {
     header("Location: ../form_page.php?status=order_error&message=" . $error_message_url);
     exit;
 } finally {
-    if (isset($stmt_ordine) && $stmt_ordine) $stmt_ordine->close();
-    if (isset($stmt_dettaglio) && $stmt_dettaglio) $stmt_dettaglio->close();
-    if ($conn) $conn->close();
+    if (isset($stmt_ordine) && $stmt_ordine instanceof mysqli_stmt) {
+        @mysqli_stmt_close($stmt_ordine);
+    }
+    if (isset($stmt_dettaglio) && $stmt_dettaglio instanceof mysqli_stmt) {
+        @mysqli_stmt_close($stmt_dettaglio);
+    }
+    if (isset($conn) && $conn instanceof mysqli) {
+        $conn->close();
+    }
 }
 ?>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpmailer/phpmailer": "^6.9"
+    }
+}

--- a/includes/mailer/mailer_config.php
+++ b/includes/mailer/mailer_config.php
@@ -1,0 +1,13 @@
+<?php
+// PHPMailer SMTP configuration
+// Fill these values with your SMTP details
+$mail_host = 'smtp.example.com';
+$mail_port = 587;
+$mail_secure = 'tls'; // tls or ssl
+$mail_username = 'user@example.com';
+$mail_password = 'secret';
+$mail_from = 'user@example.com';
+$mail_from_name = 'CRM Notifier';
+// Recipient for order notifications
+$mail_to = 'destinatario@example.com';
+?>

--- a/includes/mailer/order_mailer.php
+++ b/includes/mailer/order_mailer.php
@@ -1,0 +1,55 @@
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+$autoload = __DIR__ . '/../../vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+} else {
+    error_log('[order_mailer] vendor/autoload.php mancante. Eseguire composer install.');
+    return;
+}
+
+require_once __DIR__ . '/mailer_config.php';
+
+function sendOrderNotification($orderId, $nomeRichiedente, $centroCosto, array $prodotti) {
+    $mail = new PHPMailer(true);
+    try {
+        $mail->isSMTP();
+        $mail->Host = $GLOBALS['mail_host'];
+        $mail->Port = $GLOBALS['mail_port'];
+        $mail->SMTPSecure = $GLOBALS['mail_secure'];
+        $mail->SMTPAuth = true;
+        $mail->Username = $GLOBALS['mail_username'];
+        $mail->Password = $GLOBALS['mail_password'];
+
+        $mail->setFrom($GLOBALS['mail_from'], $GLOBALS['mail_from_name']);
+        $mail->addAddress($GLOBALS['mail_to']);
+
+        $mail->isHTML(true);
+        $mail->Subject = "Nuovo ordine #{$orderId}";
+
+        $body = "<h2>Dettagli Ordine #{$orderId}</h2>";
+        $body .= "<p><strong>Richiedente:</strong> " . htmlspecialchars($nomeRichiedente, ENT_QUOTES, 'UTF-8') . "<br>";
+        $body .= "<strong>Centro di Costo:</strong> " . htmlspecialchars($centroCosto, ENT_QUOTES, 'UTF-8') . "</p>";
+        $body .= "<h3>Prodotti</h3><ul>";
+        foreach ($prodotti as $p) {
+            $nome = htmlspecialchars($p['name'] ?? '', ENT_QUOTES, 'UTF-8');
+            $qty = (int)($p['quantity'] ?? 0);
+            $unit = htmlspecialchars($p['unit'] ?? '', ENT_QUOTES, 'UTF-8');
+            $note = htmlspecialchars($p['notes'] ?? '', ENT_QUOTES, 'UTF-8');
+            $body .= "<li>{$nome} - {$qty} {$unit}";
+            if ($note) {
+                $body .= "<br><em>{$note}</em>";
+            }
+            $body .= "</li>";
+        }
+        $body .= "</ul>";
+
+        $mail->Body = $body;
+        $mail->send();
+    } catch (Exception $e) {
+        error_log('[order_mailer] Errore invio email: ' . $mail->ErrorInfo);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- notify via email whenever an order is created
- provide SMTP configuration example
- add PHPMailer dependency via composer
- document how to install PHPMailer
- handle missing autoload more gracefully
- avoid closing DB statements twice

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68502d9dde1c832da179be511b5be38b